### PR TITLE
Mention Arch Linux package on README

### DIFF
--- a/README.org
+++ b/README.org
@@ -87,6 +87,11 @@
    $ pip3 install git+https://github.com/rndusr/stig.git@dev
    #+END_SRC
 
+   On Arch Linux it is available on AUR as
+   *[[https://aur.archlinux.org/packages/stig][stig]]*
+   and the development version as
+   *[[https://aur.archlinux.org/packages/stig-git][stig-git]]*.
+
 ** Requirements
    - Python >=3.5
    - [[http://www.urwid.org/][urwid]] >=1.3.0


### PR DESCRIPTION
I added a `stig` packages to AUR, the user maintained repository of packages of
Arch Linux. I added both a package that will track tagged releases (`stig`) and
one that follow `master` (`stig-git`) this last one depends on the git version
of `urwidtrees` for now.

I added a mention of this packages on the README, this pull request, I choose
to make it simple to not clutter the install section, most Arch Linux user are
familiar with AUR.

I branched from `dev`, should I branch from `master`?