### PR TITLE
Use xdg for determining config file paths

### DIFF
--- a/README.org
+++ b/README.org
@@ -55,11 +55,12 @@
    #+END_SRC
 
 ** Configuration and Scripting
-   All configuration is done in ~$HOME/.config/stig/rc~.  Each line is a command
-   that is called during startup.  Commands given as CLI arguments are called
-   after the rc commands.
+   All configuration is done in ~$XDG_CONFIG_HOME/stig/rc~, which expands to
+   ~$HOME/.config/stig/rc~ if you haven't changed XDG_CONFIG_HOME. Each line
+   is a command that is called during startup. Commands given as CLI arguments
+   are called after the rc commands.
 
-*** Example ~$HOME/.config/stig/rc~
+*** Example ~rc~-file
    #+BEGIN_SRC
    # Host that runs Transmission daemon
    set srv.url otherhost:123
@@ -111,7 +112,7 @@
    - [[http://www.urwid.org/][urwid]] >=1.3.0
    - [[https://github.com/pazz/urwidtrees][urwidtrees]] >=1.0.3dev0
    - [[https://pypi.python.org/pypi/aiohttp][aiohttp]]
-   - [[https://pypi.python.org/pypi/appdirs][appdirs]]
+   - [[https://pypi.python.org/pypi/xdg][xdg]]
    - [[https://pypi.python.org/pypi/blinker][blinker]]
    - [[https://pypi.python.org/pypi/natsort][natsort]]
    - [[https://pypi.python.org/pypi/asynctest/][asynctest]] (optional; only needed for running tests)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'urwid>=1.3.0',
         'urwidtrees>=1.0.3dev0',
         'aiohttp>=0.22.5',
-        'appdirs',
+        'xdg',
         'blinker',
         'natsort',
     ],

--- a/stig/settings/defaults.py
+++ b/stig/settings/defaults.py
@@ -13,7 +13,7 @@ from ..logging import make_logger
 log = make_logger(__name__)
 
 import os
-from appdirs import (user_cache_dir, user_config_dir)
+from xdg import (XDG_CONFIG_HOME, XDG_CACHE_HOME)
 
 from .. import APPNAME
 from ..views.tlist import COLUMNS as TCOLUMNS
@@ -22,8 +22,8 @@ from ..views.plist import COLUMNS as PCOLUMNS
 from ..client.sorters.tsorter import TorrentSorter
 from ..client.sorters.psorter import TorrentPeerSorter
 
-DEFAULT_RCFILE        = user_config_dir(APPNAME) + '/rc'
-DEFAULT_HISTORY_FILE  = user_cache_dir(APPNAME)+'/history'
+DEFAULT_RCFILE        = os.path.join(XDG_CONFIG_HOME, APPNAME, 'rc')
+DEFAULT_HISTORY_FILE  = os.path.join(XDG_CACHE_HOME, APPNAME, 'history')
 DEFAULT_THEME_FILE    = os.path.join(os.path.dirname(__file__), 'default.theme')
 
 DEFAULT_TLIST_SORT    = ('name',)


### PR DESCRIPTION
As per #31, this pull request removes the dependency on appdirs and uses the xdg package instead. I also took the liberty of updating the README to reflect this change.