### PR TITLE
Allow prefix of 'none' for numbers

### DIFF
--- a/stig/settings/defaults.py
+++ b/stig/settings/defaults.py
@@ -62,7 +62,7 @@ def init_defaults(cfg):
     cfg.load(
         StringValue('connect.host', default='localhost',
                     description='Hostname or IP of Transmission RPC interface'),
-        IntegerValue('connect.port', default=9091, min=1, max=65535,
+        IntegerValue('connect.port', default=9091, min=1, max=65535, prefix='none',
                      description='Port of Transmission RPC interface'),
         StringValue('connect.path', default='/transmission/rpc',
                     description='Path of Transmission RPC interface'),

--- a/stig/utils/_number.py
+++ b/stig/utils/_number.py
@@ -157,8 +157,10 @@ class _NumberBase():
             self._prefixes = self._PREFIXES_BINARY
         elif prefix == 'metric':
             self._prefixes = self._PREFIXES_METRIC
+        elif prefix == 'none':
+            self._prefixes = tuple()
         else:
-            raise ValueError("prefix must be 'binary' or 'metric', not {!r}".format(prefix))
+            raise ValueError("prefix must be 'binary', 'metric', or 'none', not {!r}".format(prefix))
         self._prefix = prefix
 
     def _do_math(self, method, *args, **kwargs):


### PR DESCRIPTION
The command `help connect.port` will display the port as 9.09k 

This fixes that by allowing a prefix of `none` for numbers that shouldn't be converted to the largest metric unit. Commands like `set connect.port += 1k` still function and preserve unitless.

Tried using the python `None` but it seems like we can't make that assumption for the prefix.