### PR TITLE
Enable authentication with blank username

### DIFF
--- a/stig/client/aiotransmission/rpc.py
+++ b/stig/client/aiotransmission/rpc.py
@@ -272,7 +272,7 @@ class TransmissionRPC():
 
             import aiohttp
             session_args = {'loop': self.loop}
-            if self.password:
+            if self.user or self.password:
                 session_args['auth'] = aiohttp.BasicAuth(self.user, self.password,
                                                          encoding='utf-8')
             self._session = aiohttp.ClientSession(**session_args)

--- a/tests/client_test/aiotransmission_test/rpc_test.py
+++ b/tests/client_test/aiotransmission_test/rpc_test.py
@@ -137,6 +137,28 @@ class TestTransmissionRPC(asynctest.ClockedTestCase):
         self.assert_cb_disconnected_called(calls=1, args=[(self.client,)])
         self.assert_cb_error_called(calls=0)
 
+    async def test_authentication_with_good_url_empty_password(self):
+        self.client.user = 'foo'
+        self.client.password = ''
+
+        # TransmissionRPC requests 'session-get' to test the connection and
+        # set version properties.
+        self.daemon.response = rsrc.SESSION_GET_RESPONSE
+        self.daemon.auth = {'user': 'foo', 'password': ''}
+
+        self.assert_not_connected_to(self.daemon.host, self.daemon.port)
+        await self.client.connect()
+        self.assert_connected_to(self.daemon.host, self.daemon.port)
+        self.assert_cb_connected_called(calls=1, args=[(self.client,)])
+        self.assert_cb_disconnected_called(calls=0)
+        self.assert_cb_error_called(calls=0)
+
+        await self.client.disconnect()
+        self.assert_not_connected_to(self.daemon.host, self.daemon.port)
+        self.assert_cb_connected_called(calls=1, args=[(self.client,)])
+        self.assert_cb_disconnected_called(calls=1, args=[(self.client,)])
+        self.assert_cb_error_called(calls=0)
+
     async def test_connect_to_bad_url(self):
         self.assert_not_connected_to(self.daemon.host, self.daemon.port)
 


### PR DESCRIPTION
Hi,

The instance of Transmission I was trying to connect to would yield `Authentication failed` with Stig. I looked into what could be the cause, and the reason was that **blank username was considered as no auth**.

Upon inspecting the tests, to add that particular scenario I came to realize the test `test_authentication_with_good_url` was actually a [_False-Negative_](http://xunitpatterns.com/false%20negative.html). I could put a blank username, change it to something else, or remove it altogether, the test would always still pass.

So I proceeded in 3 steps:
1. Fixed the false-negative test
1. Took the opportunity to refactor 2 more tests using the new mocked auth logic 
1. Implemented the failing case & fix to the bug

Each of these steps is a separate commit you can inspect.

Feel free to let me know if you'd like I make some adjustments, even if they're only cosmetic.

Thanks again for your work ;)