### PR TITLE
Update rcfile help suggestion in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -73,7 +73,7 @@
    The default rc file is ~$XDG_CONFIG_HOME/stig/rc~.  ~XDG_CONFIG_HOME~
    defaults to ~$HOME/.config~ if not set.
 
-   See ~stig help rcfile~ for more information.
+   See ~stig help cfgman~ for more information.
 
 *** Example rc file
    #+BEGIN_SRC

--- a/stig/helpmgr.py
+++ b/stig/helpmgr.py
@@ -223,7 +223,7 @@ class HelpManager():
             '\t\t- \tby providing them as command line arguments,',
             "\t\t- \tvia the command line in the TUI (press ':' to open it),",
             "\t\t- \tby binding them to keys (see 'help bind'),",
-            ("\t\t- \tby listing them in an rc file (see 'help rcfile') "
+            ("\t\t- \tby listing them in an rc file (see 'help cfgman') "
              "and loading it with the '--rcfile' option or the 'rc' command."),
             '',
             'CHAINING COMMANDS',

--- a/stig/settings/defaults.py
+++ b/stig/settings/defaults.py
@@ -228,7 +228,7 @@ DEFAULT_KEYMAP = (
      'description': 'Open help for keybindings in a new tab'},
     {'context': 'main', 'key': 'F1+f', 'action': 'tab help filters',
      'description': 'Open help for filters in a new tab'},
-    {'context': 'main', 'key': 'F1+r', 'action': 'tab help rcfile',
+    {'context': 'main', 'key': 'F1+r', 'action': 'tab help cfgman',
      'description': 'Open help for rc files in a new tab'},
     {'context': 'main', 'key': '?',    'action': '<F1>'},
 


### PR DESCRIPTION
Looks like rcfile help topic has been replaced with cfgman, configman,
and settingsmanual.