### PR TITLE
Corrected pipx development and extra install commands

### DIFF
--- a/README.org
+++ b/README.org
@@ -141,15 +141,15 @@
                          session (this requires Python headers; e.g.
                          ~apt-get install libpython3-dev~)
 
-   To install depdencies for an extra, provide the ~--spec~ option to pipx.
+   To install stig with dependencies for an extra:
    #+BEGIN_SRC sh
-   $ pipx install stig --spec 'stig[setproctitle]'
+   $ pipx install 'stig[setproctitle]'
    #+END_SRC
 
 *** Development version
-    To install the latest development version, use pipx's ~--spec~ option.
+    To install the latest development version of stig with pipx:
    #+BEGIN_SRC sh
-   $ pipx install stig --spec 'git+https://github.com/rndusr/stig.git#egg=stig'
+   $ pipx install 'git+https://github.com/rndusr/stig.git#egg=stig'
    #+END_SRC
 
 *** Developing


### PR DESCRIPTION
Fixes #137, which can be closed if this is merged. The development install command was not right : [look](https://github.com/pipxproject/pipx#installing-from-source-control) at the correct  format.