### PR TITLE
ui: Print disk space left in the download directory

### DIFF
--- a/stig/client/aiotransmission/api_freespace.py
+++ b/stig/client/aiotransmission/api_freespace.py
@@ -1,0 +1,175 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details
+# http://www.gnu.org/licenses/gpl-3.0.txt
+
+from types import SimpleNamespace
+
+import blinker
+
+from stig.utils.usertypes import Int
+from ..poll import RequestPoller
+
+from ...logging import make_logger  # isort:skip
+log = make_logger(__name__)
+
+
+class DirectorySpaceWatcher():
+    """
+    Directory space watcher on a directory defined in the Transmission settings
+    """
+
+    async def start(self, *args, **kwargs):
+        await self._poller_dirname.start(*args, **kwargs)
+        await self._poller_size.start(*args, **kwargs)
+
+    async def stop(self, *args, **kwargs):
+        await self._poller_dirname.stop(*args, **kwargs)
+        await self._poller_size.stop(*args, **kwargs)
+
+    def poll(self, *args, **kwargs):
+        self._poller_dirname.poll(*args, **kwargs)
+        self._poller_size.poll(*args, **kwargs)
+
+    @property
+    def running(self):
+        return self._poller_size.running
+
+    @property
+    def interval(self):
+        return self._poller_size.interval
+
+    @interval.setter
+    def interval(self, interval):
+        self._poller_dirname.interval = interval
+        self._poller_size.interval = interval
+
+    def __init__(self, srvapi, setting_poller, interval=1):
+        self._srvapi = srvapi
+        self._on_update = blinker.Signal()
+
+        self._poller_dirname = RequestPoller(setting_poller,
+                                             interval=interval)
+        self._poller_dirname.on_response(self._handle_dirname)
+        self._poller_dirname.on_error(self._handle_dirname_error,
+                                      autoremove=False)
+
+        self._poller_size = RequestPoller(srvapi.rpc.free_space,
+                                          path="",
+                                          interval=interval)
+        self._poller_size.on_response(self._handle_size)
+        self._poller_size.on_error(self._handle_size_error,
+                                   autoremove=False)
+
+        self.space_info = SimpleNamespace(path=None,
+                                          size=None)
+
+    def _handle_dirname(self, path):
+        if path is not None and path != "disabled":
+            self.space_info.path = path
+            self._poller_size.skip_ongoing_request()
+            self._poller_size.set_request(self._srvapi.rpc.free_space,
+                                          path=path)
+
+    def _handle_dirname_error(self, error):
+        log.debug('Ignoring exception: %r', error)
+
+    def _handle_size(self, response):
+        if response is not None \
+           and self.space_info.path == response['path']:
+            self.space_info.size = Int(response['size-bytes'])
+            self._on_update.send(self.space_info)
+
+    def _handle_size_error(self, error):
+        if not self.space_info.path:
+            log.debug('Ignoring exception: %r', error)
+        else:
+            raise error
+
+    def on_update(self, callback, autoremove=True):
+        """
+        Register `callback` to be called when settings have changed
+
+        `callback` gets the instance of this class.
+
+        If `autoremove` is True, `callback` is removed automatically when it is
+        deleted.
+        """
+        log.debug('Registering %r to receive updates about free space', callback)
+        self._on_update.connect(callback, weak=autoremove)
+
+
+class FreeSpaceAPI():
+    """
+    Transmission daemon free space method handler
+    """
+
+    async def start(self, *args, **kwargs):
+        await self._watcher_complete.start(*args, **kwargs)
+        await self._watcher_incomplete.start(*args, **kwargs)
+
+    async def stop(self, *args, **kwargs):
+        await self._watcher_complete.stop(*args, **kwargs)
+        await self._watcher_incomplete.stop(*args, **kwargs)
+
+    def poll(self, *args, **kwargs):
+        self._watcher_complete.poll(*args, **kwargs)
+        self._watcher_incomplete.poll(*args, **kwargs)
+
+    @property
+    def running(self):
+        return self._watcher_incomplete.running \
+               and self._watcher_incomplete.running
+
+    @property
+    def interval(self):
+        return self._watcher_complete.interval
+
+    @interval.setter
+    def interval(self, interval):
+        self._watcher_complete.interval = interval
+        self._watcher_incomplete.interval = interval
+
+    @property
+    def complete_info(self):
+        return self._watcher_complete.space_info
+
+    @property
+    def incomplete_info(self):
+        return self._watcher_incomplete.space_info
+
+    def __init__(self, srvapi, interval=1):
+        self._on_update = blinker.Signal()
+
+        self._watcher_complete = DirectorySpaceWatcher(srvapi,
+                                                       srvapi.settings.get_path_complete,
+                                                       interval)
+        self._watcher_complete.on_update(self._send_update)
+
+        self._watcher_incomplete = DirectorySpaceWatcher(srvapi,
+                                                         srvapi.settings.get_path_incomplete,
+                                                         interval)
+        self._watcher_incomplete.on_update(self._send_update)
+
+    def _send_update(self, *args):
+        log.debug('Free space: %r / %r',
+                  self.complete_info, self.incomplete_info)
+        self._on_update.send(self)
+
+    def on_update(self, callback, autoremove=True):
+        """
+        Register `callback` to be called when settings have changed
+
+        `callback` gets the instance of this class.
+
+        If `autoremove` is True, `callback` is removed automatically when it is
+        deleted.
+        """
+        log.debug('Registering %r to receive updates about free space', callback)
+        self._on_update.connect(callback, weak=autoremove)

--- a/stig/client/aiotransmission/api_freespace.py
+++ b/stig/client/aiotransmission/api_freespace.py
@@ -15,6 +15,7 @@ import blinker
 
 from stig.utils.usertypes import Int
 from ..poll import RequestPoller
+from ..errors import TimeoutError
 
 from ...logging import make_logger  # isort:skip
 log = make_logger(__name__)
@@ -87,7 +88,8 @@ class DirectorySpaceWatcher():
             self._on_update.send(self.space_info)
 
     def _handle_size_error(self, error):
-        if not self.space_info.path:
+        if not self.space_info.path \
+           or isinstance(error, TimeoutError):
             log.debug('Ignoring exception: %r', error)
         else:
             raise error

--- a/stig/client/api.py
+++ b/stig/client/api.py
@@ -14,6 +14,7 @@ import asyncio
 from . import errors
 from .aiotransmission.api_settings import SettingsAPI
 from .aiotransmission.api_status import StatusAPI
+from .aiotransmission.api_freespace import FreeSpaceAPI
 from .aiotransmission.api_torrent import TorrentAPI
 from .aiotransmission.rpc import TransmissionRPC
 from .poll import RequestPoller
@@ -29,9 +30,9 @@ class API():
     Provide and manage *API classes as singletons
 
     A convenience class that provides instances of TransmissionRPC, TorrentAPI,
-    StatusAPI, TorrentRequestPool and TorrentCounters and all ClientError
-    exceptions in one object. All instances except TransmissionRPC are created
-    lazily on demand.
+    StatusAPI, FreeSpaceAPI, TorrentRequestPool and TorrentCounters and all
+    ClientError exceptions in one object. All instances except TransmissionRPC
+    are created lazily on demand.
     """
 
     # Make errors available without having to import them everywhere
@@ -80,6 +81,12 @@ class API():
         """StatusAPI singleton"""
         log.debug('Creating StatusAPI singleton')
         return StatusAPI(self, interval=self._interval)
+
+    @cached_property(after_creation=lambda self: setattr(self, 'freespace_created', True))
+    def freespace(self):
+        """FreeSpaceAPI singleton"""
+        log.debug('Creating FreeSpaceAPI singleton')
+        return FreeSpaceAPI(self, interval=self._interval)
 
     @cached_property(after_creation=lambda self: setattr(self, 'settings_created', True))
     def settings(self):
@@ -160,7 +167,7 @@ class API():
         self._manage_pollers_interval.interrupt()
 
     # Standard pollers accessible through properties
-    _STD_POLLERS = ('status', 'settings', 'treqpool')
+    _STD_POLLERS = ('status', 'freespace', 'settings', 'treqpool')
     @property
     def _existing_pollers(self):
         for pname in self._STD_POLLERS:

--- a/stig/tui/miscwidgets.py
+++ b/stig/tui/miscwidgets.py
@@ -337,6 +337,30 @@ class TorrentCountersWidget(urwid.WidgetWrap):
         self._text.set_text(text)
 
 
+class AvailableDiskSpaceWidget(urwid.WidgetWrap):
+    def __init__(self):
+        self._text = urwid.Text(EMPTY_TEXT)
+        super().__init__(urwid.AttrMap(self._text, 'bottombar'))
+        objects.srvapi.freespace.on_update(self._update_diskspace)
+
+    def _update_diskspace(self, freespace):
+        text = []
+        if freespace.complete_info.size < 1024:
+            text.append(('bottombar.important', '%sB' % freespace.complete_info.size))
+        else:
+            text.append('%sB' % freespace.complete_info.size)
+
+        if freespace.incomplete_info.size is not None \
+           and freespace.complete_info.path != freespace.incomplete_info.path:
+            text[-1] += '/'
+            if freespace.incomplete_info.size < 1024:
+                text.append(('bottombar.important', '%sB' % freespace.incomplete_info.size))
+            else:
+                text.append('%sB' % freespace.incomplete_info.size)
+
+        self._text.set_text(text)
+
+
 class MarkedItemsWidget(urwid.WidgetWrap):
     def __init__(self):
         self._text = urwid.Text(('bottombar', ' '))

--- a/stig/tui/tuiobjects.py
+++ b/stig/tui/tuiobjects.py
@@ -24,7 +24,8 @@ from .group import Group
 from .keymap import KeyMap
 from .logger import LogWidget
 from .miscwidgets import (BandwidthStatusWidget, ConnectionStatusWidget, KeyChainsWidget,
-                          MarkedItemsWidget, QuickHelpWidget, TorrentCountersWidget)
+                          MarkedItemsWidget, QuickHelpWidget, TorrentCountersWidget,
+                          AvailableDiskSpaceWidget)
 from .tabs import TabBar, Tabs
 
 from ..logging import make_logger  # isort:skip
@@ -91,9 +92,12 @@ tabs = keymap.wrap(Tabs, context='tabs')(
 
 bottombar = Group(cls=urwid.Columns)
 bottombar.add(name='counters', widget=TorrentCountersWidget(), options='pack')
-bottombar.add(name='_spacer1', widget=urwid.AttrMap(_greedy_spacer(), 'bottombar'))
-bottombar.add(name='marked', widget=MarkedItemsWidget(), options='pack')
+bottombar.add(name='_spacer1', widget=urwid.AttrMap(urwid.Text(' '), 'bottombar'),
+              options='pack')
+bottombar.add(name='diskspace', widget=AvailableDiskSpaceWidget(), options='pack')
 bottombar.add(name='_spacer2', widget=urwid.AttrMap(_greedy_spacer(), 'bottombar'))
+bottombar.add(name='marked', widget=MarkedItemsWidget(), options='pack')
+bottombar.add(name='_spacer3', widget=urwid.AttrMap(_greedy_spacer(), 'bottombar'))
 bottombar.add(name='bandwidth', widget=BandwidthStatusWidget(), options='pack')
 
 cli = urwid.AttrMap(_create_cli_widget(), 'cli')


### PR DESCRIPTION
This commit adds a widget in the bottom bar that displays the amount
of space left in the download directory.

A new poller is implemented that queries the path to the download
directory from the Transmission daemon, and sends it back in a standard
"Free Space" query[1].

If the "incomplete download directory" feature is not disabled and
is different than the regular download directory, it will also be
displayed (separated from the other number with a slash).

Both numbers are pretty printed (e.g. "1KB" instead of "1024"),
and tagged as "important" when below 104 bytes.

[1] https://trac.transmissionbt.com/browser/trunk/extras/rpc-spec.txt#L603

Fixes #146