### PR TITLE
Ability to unbind a key from all contexts at once

### DIFF
--- a/stig/commands/tui/tui.py
+++ b/stig/commands/tui/tui.py
@@ -174,13 +174,22 @@ class UnbindCmd(metaclass=CommandMeta):
          'description': 'Keys or key combinations (see "bind" command)'},
     )
 
+    more_sections = {
+        'COMPLETE UNBINDING': (
+            ('For this command there is a special context called \'all\' that '
+            'unbinds the key for every context.'),
+            '',
+            'Note that \'unbind --all\' is very different from \'unbind --context all\''
+        )
+    }
+
     def run(self, context, all, KEY):
         from ...tui.tuiobjects import keymap
         if all:
             keymap.clear(context=context)
         if context is None:
             context = keymap.DEFAULT_CONTEXT
-        elif context not in _get_keymap_contexts():
+        elif context not in _get_keymap_contexts() and context != keymap.ALL_CONTEXTS:
             raise CmdError('Invalid context: %r' % (context,))
 
         success = True

--- a/tests/tui_test/keymap_test.py
+++ b/tests/tui_test/keymap_test.py
@@ -278,6 +278,19 @@ class TestKeyMap_with_single_keys(unittest.TestCase):
         self.assertIn("Key not mapped in context 'default'", str(cm.exception))
         self.assertIn(str(Key('e')), str(cm.exception))
 
+        self.km.bind(key='f', action='foo')
+        self.km.bind(key='f', action='foo', context='fubar')
+        self.km.bind(key='f', action='food', context='imhungry')
+        self.km.unbind(key='f')
+        self.assertIn(Key('f'), self.km.keys())
+        self.km.unbind(key='f', context='all')
+        self.assertNotIn(Key('f'), self.km.keys())
+        
+        with self.assertRaises(ValueError) as cm:
+            self.km.unbind(key='f', context='all')
+        self.assertIn("not mapped in any context", str(cm.exception))
+        self.assertIn(str(Key('f')), str(cm.exception))
+
     def test_mkkey(self):
         self.assertEqual(self.km.mkkey(Key('x')), Key('x'))
         self.assertEqual(self.km.mkkey(KeyChain('1', '2', '3')),


### PR DESCRIPTION
The `unbind` command may be insufficient, especially for those who use a non-qwerty keyboard layout, because there's no way to _completely_ unbind a key. If you want 'n' to be the key for `<down>` and tried `bind n <down>`, then one would be quite annoyed to find that the key is still bound in the `helptext` and `tab` contexts.

One idea would be to bind a key to a certain action in all contexts, but many actions only make sense in a particular one and `default` is supposed to handle that anyway.

Instead I think it's much better to give `unbind` the _pseudo_-context `all` which completely unbinds the key in all contexts.

FYI: This passes both the commands test and the tui test.