### PR TITLE
add features to get and set the seed ratio limit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@
   Other changes:
     * "unbind --all t" now unbinds "t" in all keybinding contexts.
 
+  Fixed bugs:
+    * Removed tilde expansion from completion candidates for the :move command
+
 
 2021-02-09 0.12.1a0
   Fixed bugs:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+????-??-?? ?.??.??
+  Other changes:
+    * "unbind --all t" now unbinds "t" in all keybinding contexts.
+
+
 2021-02-09 0.12.1a0
   Fixed bugs:
     * Fix "Unclosed client session" error when not using the TUI

--- a/stig/client/aiotransmission/api_settings.py
+++ b/stig/client/aiotransmission/api_settings.py
@@ -16,7 +16,7 @@ from types import SimpleNamespace
 import blinker
 
 from ..poll import RequestPoller
-from ..utils import Bool, BoolOrBandwidth, BoolOrPath, Int, Option, Path, const, convert
+from ..utils import Bool, BoolOrBandwidth, BoolOrPath, Float, Int, Option, Path, const, convert
 
 from ...logging import make_logger  # isort:skip
 log = make_logger(__name__)
@@ -335,6 +335,30 @@ class SettingsAPI(abc.Mapping, RequestPoller):
         value = self._converters['limit.peers.torrent'](limit)
         await self._set('limit.peers.torrent', {'peer-limit-per-torrent': value})
 
+
+    @_setting(Float)
+    def limit_ratio(self):
+        """Default seed ratio limit"""
+        return self._get("limit.ratio", 'seedRatioLimit')
+
+    async def get_limit_ratio(self):
+        await self.update()
+        return self.limit_ratio
+
+    async def set_limit_ratio(self, value):
+        await self._set('limit.ratio', {'seedRatioLimit': value})
+
+    @_setting(Bool)
+    def limit_ratio_enabled(self):
+        """Whether global ratio limit is respected by default"""
+        return self._get('limit.ratio.enabled', 'seedRatioLimited')
+
+    async def get_limit_ratio_enabled(self):
+        await self.update()
+        return self.limit_ratio_enabled
+
+    async def set_limit_ratio_enabled(self, value):
+        await self._set('limit.ratio.enabled', {'seedRatioLimited': value})
 
     @_setting(Option, options=('required', 'preferred', 'tolerated'),
               description='Protocol encryption policy; "required", "preferred" or "tolerated"')

--- a/stig/client/utils.py
+++ b/stig/client/utils.py
@@ -145,6 +145,15 @@ class Ratio(Float):
         else:
             return super().without_unit
 
+class RatioLimitMode:
+    """A Torrent's ratio limit mode as a string"""
+    GLOBAL = "default"
+    SINGLE = "override"
+    UNLIMITED = "unlimited"
+    DISABLED = "disabled"
+
+    pass
+
 
 class Status(tuple):
     """A Torrent's status as a tuple of strings"""

--- a/stig/commands/base/torrent.py
+++ b/stig/commands/base/torrent.py
@@ -427,6 +427,27 @@ class RenameCmdbase(metaclass=CommandMeta):
                 log.debug('Using torrent names as destination candidates')
                 return await candidates.torrent_filter(args.curarg, filter_names=False)
 
+class SetTorrentSeedRatioLimit(metaclass=CommandMeta):
+    name = 'setseedratiolimit'
+    aliases = ()
+    provides = set()
+    category = 'torrent'
+    description = 'Set the seed ratio limit for a torrent'
+    usage = ('setseedratiolimit <LIMIT>',
+             'setseedratiolimit <TORRENT> <LIMIT>)')
+    examples = ('setseedratiolimit 2',
+                "start 'night of the living dead' Metropolis",
+                'start ubuntu --force')
+    argspecs = (
+        make_X_FILTER_spec('TORRENT', or_focused=True, nargs='?'),
+
+        {'names': ('LIMIT',),
+         'description': 'New seed limit ratio '
+        }
+    )
+
+    async def run(self, TORRENT_FILTER, LIMIT):
+        response = await self.make_request(objects.srvapi.torrent.set_seed_ratio_limit(TORRENT_FILTER, LIMIT))
 
 # Argument definitions that are shared between commands
 ARGSPEC_TOGGLE = {

--- a/stig/commands/cli/torrent.py
+++ b/stig/commands/cli/torrent.py
@@ -158,6 +158,8 @@ class StartTorrentsCmd(base.StartTorrentsCmdbase,
                        mixin.make_request, mixin.select_torrents):
     provides = {'cli'}
 
+class SetTorrentSeedRatioLimit(base.SetTorrentSeedRatioLimit, mixin.make_request):
+    provides = {'cli'}
 
 class StopTorrentsCmd(base.StopTorrentsCmdbase,
                       mixin.make_request, mixin.select_torrents):

--- a/stig/commands/tui/torrent.py
+++ b/stig/commands/tui/torrent.py
@@ -188,6 +188,8 @@ class StartTorrentsCmd(base.StartTorrentsCmdbase,
                        mixin.polling_frenzy, mixin.make_request, mixin.select_torrents):
     provides = {'tui'}
 
+class SetTorrentSeedRatioLimit(base.SetTorrentSeedRatioLimit, mixin.make_request):
+    provides = {'tui'}
 
 class StopTorrentsCmd(base.StopTorrentsCmdbase,
                       mixin.polling_frenzy, mixin.make_request, mixin.select_torrents):

--- a/stig/commands/tui/torrent.py
+++ b/stig/commands/tui/torrent.py
@@ -106,7 +106,8 @@ class MoveTorrentsCmd(base.MoveTorrentsCmdbase,
         def dest_path_candidates(curarg):
             return candidates.fs_path(curarg.before_cursor,
                                       base=objects.cfg['srv.path.complete'],
-                                      directories_only=True)
+                                      directories_only=True,
+                                      expand_home_directory=False)
 
         curarg = args.curarg
         if len(args) >= 3:

--- a/stig/completion/candidates.py
+++ b/stig/completion/candidates.py
@@ -183,18 +183,19 @@ def keybinding_keys(args):
     return Candidates(keys, label=label)
 
 
-def fs_path(path, base='.', directories_only=False, glob=None, regex=None):
+def fs_path(path, base='.', directories_only=False, expand_home_directory=True, glob=None, regex=None):
     """
     File system path entries
 
     path: Path to get entries from
     base: Absolute path that is prepended to `path` if `path` is not absolute
     directories_only: Whether to include only directories
+    expand_home_directory: Whether to interpret "~"
     glob: Unix shell pattern
     regex: Regular expression that is matched against each name in `path`
     """
     log.debug('Getting path candidates for %r', path)
-    if path.startswith('~') and os.sep not in path:
+    if path.startswith('~') and os.sep not in path and expand_home_directory:
         # Complete home dirs in "~<user>" style
         import pwd
         users = pwd.getpwall()
@@ -202,7 +203,10 @@ def fs_path(path, base='.', directories_only=False, glob=None, regex=None):
         label = 'Home directories'
     else:
         include_hidden = os.path.basename(path).startswith('.')
-        dirpath = os.path.expanduser(path)
+        if expand_home_directory:
+            dirpath = os.path.expanduser(path)
+        else:
+            dirpath = path
         if not os.path.isabs(dirpath):
             dirpath = os.path.join(base, dirpath)
         dirpath = os.path.dirname(dirpath)

--- a/stig/settings/defaults.py
+++ b/stig/settings/defaults.py
@@ -14,7 +14,7 @@ import os
 from xdg.BaseDirectory import xdg_config_home as XDG_CONFIG_HOME
 from xdg.BaseDirectory import xdg_data_home as XDG_DATA_HOME
 
-from .. import __appname__, objects
+from .. import __appname__
 from ..client.sorters import PeerSorter, SettingSorter, TorrentSorter, TrackerSorter
 from ..utils import convert
 from ..utils.usertypes import Bool, Float, Int, Option, Path, String, Tuple
@@ -85,6 +85,8 @@ class Bytes(Int):
 
 
 def init_defaults(localcfg):
+    from .. import objects
+
     localcfg.add('connect.host',
                  String.partial(),
                  getter=lambda: objects.srvapi.rpc.host,

--- a/stig/tui/keymap.py
+++ b/stig/tui/keymap.py
@@ -241,7 +241,7 @@ class KeyMap():
     """
 
     NO_CONTEXT      = object()
-    ALL_CONTEXTS    = 'all'
+    ALL_CONTEXTS    = object()
     DEFAULT_CONTEXT = 'default'
 
     def __init__(self, callback=None):
@@ -324,7 +324,7 @@ class KeyMap():
             return key_removed
 
         key = self.mkkey(key)
-        if context == self.ALL_CONTEXTS:
+        if context is self.ALL_CONTEXTS:
             keys_removed = [_unbind(key, context) for context in self._actions]
             if not any(keys_removed):
                 raise ValueError('Key %s not mapped in any context.' % (key,))
@@ -450,7 +450,7 @@ class KeyMap():
                 if isinstance(kc, KeyChain):
                     yield (kc, action)
 
-        if context == self.ALL_CONTEXTS:
+        if context is self.ALL_CONTEXTS:
             for cntxt in self.contexts:
                 yield from keychains_from(cntxt)
         else:

--- a/stig/tui/tuiobjects.py
+++ b/stig/tui/tuiobjects.py
@@ -32,6 +32,9 @@ from ..logging import make_logger  # isort:skip
 log = make_logger(__name__)
 
 
+urwidpatches.apply_patches()
+
+
 keymap = KeyMap(callback=lambda cmd,widget: objects.cmdmgr.run_task(cmd, on_error=log.error))
 for args in DEFAULT_KEYMAP:
     if args['action'][0] == '<' and args['action'][-1] == '>':

--- a/stig/tui/urwidpatches.py
+++ b/stig/tui/urwidpatches.py
@@ -11,58 +11,76 @@
 
 """Monkey patches that should be removed when they are resolved upstream"""
 
+import importlib
 import urwid
 
-# Add more actions for key bindings
-urwid.CURSOR_WORD_LEFT         = 'cursor word left'
-urwid.CURSOR_WORD_RIGHT        = 'cursor word right'
-urwid.DELETE_TO_EOL            = 'delete to end of line'
-urwid.DELETE_LINE              = 'delete line'
-urwid.DELETE_CHAR_UNDER_CURSOR = 'delete char under cursor'
-urwid.DELETE_WORD_LEFT         = 'delete word left'
-urwid.DELETE_WORD_RIGHT        = 'delete word right'
-urwid.CANCEL                   = 'cancel'
-urwid.COMPLETE_NEXT            = 'complete next'
-urwid.COMPLETE_PREV            = 'complete previous'
+# Map class name to patched class
+_patched_classes = {}
+_unpatched_classes = {}
 
-# Remove urwid's default keybindings and create our own built-in command_map
-for key in tuple(urwid.command_map._command):
-    del urwid.command_map._command[key]
+def apply_patches():
+    importlib.reload(urwid)
 
-from .keymap import Key  # noqa isort:skip
-urwid.command_map[Key('pgup')]           = urwid.CURSOR_PAGE_UP
-urwid.command_map[Key('pgdn')]           = urwid.CURSOR_PAGE_DOWN
-urwid.command_map[Key('ctrl-b')]         = urwid.CURSOR_PAGE_UP
-urwid.command_map[Key('ctrl-f')]         = urwid.CURSOR_PAGE_DOWN
-urwid.command_map[Key('b')]              = urwid.CURSOR_PAGE_UP
-urwid.command_map[Key('space')]          = urwid.CURSOR_PAGE_DOWN
+    for cls_name,cls_patched in _patched_classes.items():
+        _unpatched_classes[cls_name] = getattr(urwid, cls_name)
+        setattr(urwid, cls_name, cls_patched)
 
-urwid.command_map[Key('up')]             = urwid.CURSOR_UP
-urwid.command_map[Key('down')]           = urwid.CURSOR_DOWN
-urwid.command_map[Key('left')]           = urwid.CURSOR_LEFT
-urwid.command_map[Key('right')]          = urwid.CURSOR_RIGHT
-urwid.command_map[Key('meta-b')]         = urwid.CURSOR_WORD_LEFT
-urwid.command_map[Key('meta-f')]         = urwid.CURSOR_WORD_RIGHT
+    # Add more actions for key bindings
+    urwid.CURSOR_WORD_LEFT         = 'cursor word left'
+    urwid.CURSOR_WORD_RIGHT        = 'cursor word right'
+    urwid.DELETE_TO_EOL            = 'delete to end of line'
+    urwid.DELETE_LINE              = 'delete line'
+    urwid.DELETE_CHAR_UNDER_CURSOR = 'delete char under cursor'
+    urwid.DELETE_WORD_LEFT         = 'delete word left'
+    urwid.DELETE_WORD_RIGHT        = 'delete word right'
+    urwid.CANCEL                   = 'cancel'
+    urwid.COMPLETE_NEXT            = 'complete next'
+    urwid.COMPLETE_PREV            = 'complete previous'
 
-urwid.command_map[Key('home')]           = urwid.CURSOR_MAX_LEFT
-urwid.command_map[Key('end')]            = urwid.CURSOR_MAX_RIGHT
-urwid.command_map[Key('ctrl-a')]         = urwid.CURSOR_MAX_LEFT
-urwid.command_map[Key('ctrl-e')]         = urwid.CURSOR_MAX_RIGHT
+    # Remove urwid's default keybindings and create our own built-in command_map
+    for key in tuple(urwid.command_map._command):
+        del urwid.command_map._command[key]
 
-urwid.command_map[Key('ctrl-k')]         = urwid.DELETE_TO_EOL
-urwid.command_map[Key('ctrl-u')]         = urwid.DELETE_LINE
-urwid.command_map[Key('ctrl-d')]         = urwid.DELETE_CHAR_UNDER_CURSOR
-urwid.command_map[Key('meta-d')]         = urwid.DELETE_WORD_LEFT
-urwid.command_map[Key('meta-backspace')] = urwid.DELETE_WORD_RIGHT
-urwid.command_map[Key('ctrl-w')]         = urwid.DELETE_WORD_RIGHT
+    from .keymap import Key  # noqa isort:skip
+    urwid.command_map[Key('pgup')]           = urwid.CURSOR_PAGE_UP
+    urwid.command_map[Key('pgdn')]           = urwid.CURSOR_PAGE_DOWN
+    urwid.command_map[Key('ctrl-b')]         = urwid.CURSOR_PAGE_UP
+    urwid.command_map[Key('ctrl-f')]         = urwid.CURSOR_PAGE_DOWN
+    urwid.command_map[Key('b')]              = urwid.CURSOR_PAGE_UP
+    urwid.command_map[Key('space')]          = urwid.CURSOR_PAGE_DOWN
 
-urwid.command_map[Key('enter')]          = urwid.ACTIVATE
-urwid.command_map[Key('escape')]         = urwid.CANCEL
-urwid.command_map[Key('ctrl-g')]         = urwid.CANCEL
-urwid.command_map[Key('ctrl-c')]         = urwid.CANCEL
-urwid.command_map[Key('ctrl-l')]         = urwid.REDRAW_SCREEN
-urwid.command_map[Key('tab')]            = urwid.COMPLETE_NEXT
-urwid.command_map[Key('shift-tab')]      = urwid.COMPLETE_PREV
+    urwid.command_map[Key('up')]             = urwid.CURSOR_UP
+    urwid.command_map[Key('down')]           = urwid.CURSOR_DOWN
+    urwid.command_map[Key('left')]           = urwid.CURSOR_LEFT
+    urwid.command_map[Key('right')]          = urwid.CURSOR_RIGHT
+    urwid.command_map[Key('meta-b')]         = urwid.CURSOR_WORD_LEFT
+    urwid.command_map[Key('meta-f')]         = urwid.CURSOR_WORD_RIGHT
+
+    urwid.command_map[Key('home')]           = urwid.CURSOR_MAX_LEFT
+    urwid.command_map[Key('end')]            = urwid.CURSOR_MAX_RIGHT
+    urwid.command_map[Key('ctrl-a')]         = urwid.CURSOR_MAX_LEFT
+    urwid.command_map[Key('ctrl-e')]         = urwid.CURSOR_MAX_RIGHT
+
+    urwid.command_map[Key('ctrl-k')]         = urwid.DELETE_TO_EOL
+    urwid.command_map[Key('ctrl-u')]         = urwid.DELETE_LINE
+    urwid.command_map[Key('ctrl-d')]         = urwid.DELETE_CHAR_UNDER_CURSOR
+    urwid.command_map[Key('meta-d')]         = urwid.DELETE_WORD_LEFT
+    urwid.command_map[Key('meta-backspace')] = urwid.DELETE_WORD_RIGHT
+    urwid.command_map[Key('ctrl-w')]         = urwid.DELETE_WORD_RIGHT
+
+    urwid.command_map[Key('enter')]          = urwid.ACTIVATE
+    urwid.command_map[Key('escape')]         = urwid.CANCEL
+    urwid.command_map[Key('ctrl-g')]         = urwid.CANCEL
+    urwid.command_map[Key('ctrl-c')]         = urwid.CANCEL
+    urwid.command_map[Key('ctrl-l')]         = urwid.REDRAW_SCREEN
+    urwid.command_map[Key('tab')]            = urwid.COMPLETE_NEXT
+    urwid.command_map[Key('shift-tab')]      = urwid.COMPLETE_PREV
+
+def revert_patches():
+    for cls_name in _patched_classes:
+        cls_unpatched = _unpatched_classes[cls_name]
+        setattr(urwid, cls_name, cls_unpatched)
+    urwid.command_map.restore_defaults()
 
 
 import re        # noqa isort:skip
@@ -116,7 +134,7 @@ class Edit_readline(urwid.Edit):
         else:
             return super().keypress(size, key)
 
-urwid.Edit = Edit_readline
+_patched_classes['Edit'] = Edit_readline
 
 
 # Remove Text._calc_line_translation() to fix rare crash on peer lists.
@@ -142,7 +160,7 @@ class Text_patched(urwid.Text):
         self._cache_translation = self.layout.layout(
             text, maxcol, self._align_mode, self._wrap_mode)
 
-urwid.Text = Text_patched
+_patched_classes['Text'] = Text_patched
 
 
 # Limit the impact of the high CPU load bug
@@ -174,7 +192,7 @@ class AsyncioEventLoop_patched(urwid.AsyncioEventLoop):
         if self._exc_info:
             raise self._exc_info
 
-urwid.AsyncioEventLoop = AsyncioEventLoop_patched
+_patched_classes['AsyncioEventLoop'] = AsyncioEventLoop_patched
 
 
 # Add support for ScrollBar class (see stig.tui.scroll)
@@ -227,7 +245,7 @@ class ListBox_patched(urwid.ListBox):
                 self._rows_max = sum(w.rows(flow_size) for w in self.body)
         return self._rows_max
 
-urwid.ListBox = ListBox_patched
+_patched_classes['ListBox'] = ListBox_patched
 
 
 # Don't use deprecated inspect.getargspect()

--- a/stig/tui/views/torrent.py
+++ b/stig/tui/views/torrent.py
@@ -267,32 +267,6 @@ class Ratio(_COLUMNS['ratio'], CellWidgetBase):
 TUICOLUMNS['ratio'] = Ratio
 
 
-class LimitRatio(_COLUMNS['limit-ratio'], CellWidgetBase):
-    style = Style(prefix='torrentlist.limit-ratio', focusable=True,
-                  extras=('header',), modes=('highlighted',))
-    header = urwid.AttrMap(ColumnHeaderWidget(**_COLUMNS['limit-ratio'].header),
-                           style.attrs('header'))
-
-    def get_mode(self):
-        if self.data['limit-ratio-mode'] != 'default':
-            return 'highlighted'
-
-TUICOLUMNS['limit-ratio'] = LimitRatio
-
-
-class LimitRatioMode(_COLUMNS['limit-ratio-mode'], CellWidgetBase):
-    style = Style(prefix='torrentlist.limit-ratio-mode', focusable=True,
-                  extras=('header',), modes=('highlighted',))
-    header = urwid.AttrMap(ColumnHeaderWidget(**_COLUMNS['limit-ratio-mode'].header),
-                           style.attrs('header'))
-
-    def get_mode(self):
-        if self.data['limit-ratio-mode'] != 'default':
-            return 'highlighted'
-
-TUICOLUMNS['limit-ratio-mode'] = LimitRatioMode
-
-
 class RateUp(_COLUMNS['rate-up'], CellWidgetBase):
     style = Style(prefix='torrentlist.rate-up', focusable=True,
                   extras=('header',), modes=('highlighted',))
@@ -340,6 +314,21 @@ class LimitRateDown(_COLUMNS['limit-rate-down'], CellWidgetBase):
 
 TUICOLUMNS['limit-rate-down'] = LimitRateDown
 
+class LimitRatio(_COLUMNS['limit-ratio'], CellWidgetBase):
+    style = Style(prefix='torrentlist.limit-ratio', focusable=True,
+                  extras=('header',), )
+    header = urwid.AttrMap(ColumnHeaderWidget(**_COLUMNS['limit-ratio'].header),
+                           style.attrs('header'))
+
+TUICOLUMNS['limit-ratio'] = LimitRatio
+
+class LimitRatioMode(_COLUMNS['limit-ratio-mode'], CellWidgetBase):
+    style = Style(prefix='torrentlist.limit-ratio-mode', focusable=True,
+                  extras=('header',), )
+    header = urwid.AttrMap(ColumnHeaderWidget(**_COLUMNS['limit-ratio-mode'].header),
+                           style.attrs('header'))
+
+TUICOLUMNS['limit-ratio-mode'] = LimitRatioMode
 
 class Tracker(_COLUMNS['tracker'], CellWidgetBase):
     style = Style(prefix='torrentlist.tracker', focusable=True,

--- a/stig/views/details.py
+++ b/stig/views/details.py
@@ -12,7 +12,10 @@
 """TUI and CLI specs for torrent details sections"""
 
 from functools import partial
+import sys
 
+from ..client.utils import RatioLimitMode
+from ..objects import remotecfg
 from ..logging import make_logger  # isort:skip
 log = make_logger(__name__)
 
@@ -63,7 +66,6 @@ def _private_hr(t):
 def _private_mr(t):
     return 'yes' if t['private'] else 'no'
 
-
 def _status_hr(t):
     return ', '.join(t['status'])
 
@@ -102,6 +104,22 @@ def _ratio_hr(t):
     else:
         return '%g' % ratio
 _ratio_mr = _ratio_hr
+
+def _seed_ratio_limit_hr(t):
+    limit = t['seed-ratio-limit']
+    mode  = t['seed-ratio-mode']
+    default = remotecfg['srv.limit.ratio']
+    enabled = remotecfg['srv.limit.ratio.enabled']
+    if mode == RatioLimitMode.GLOBAL:
+        if enabled:
+            return RatioLimitMode.DISABLED
+        limit = default
+    return '%g (%s)' % (limit, mode)
+def _seed_ratio_limit_mr(t):
+    return _seed_ratio_limit_hr(t)
+    ratio = t['seed-ratio-limit']
+    mode  = t['seed-ratio-mode']
+    return '%g (%s)' % (ratio, mode)
 
 
 def _available_hr(t):
@@ -214,6 +232,10 @@ SECTIONS = (
              needed_keys=('ratio',),
              human_readable=_ratio_hr,
              machine_readable=_ratio_mr),
+        Item('Ratio limit',
+             needed_keys=('seed-ratio-limit',),
+             human_readable=_seed_ratio_limit_hr,
+             machine_readable=_seed_ratio_limit_mr),
         Item('Isolated',
              needed_keys=('status',),
              human_readable=_isolated_hr,

--- a/stig/views/torrent.py
+++ b/stig/views/torrent.py
@@ -14,6 +14,8 @@
 import os
 
 from . import ColumnBase, _ensure_hide_unit
+from ..client.utils import RatioLimitMode
+# from ..objects import remotecfg
 
 from ..logging import make_logger  # isort:skip
 log = make_logger(__name__)
@@ -320,6 +322,34 @@ class Ratio(ColumnBase):
         return self.data['ratio']
 
 COLUMNS['ratio'] = Ratio
+
+class SeedRatioLimit(ColumnBase):
+    header = {'left': 'Ratio limit'}
+    width = 5
+    min_width = 5
+    needed_keys = ('seed-ratio-limit',)
+
+    def get_value(self):
+        limit = self.data['seed-ratio-limit']
+        mode = self.data['seed-ratio-mode']
+        # default = remotecfg['srv.limit.ratio']
+        # enabled = remotecfg['srv.limit.ratio.enabled']
+        if mode == RatioLimitMode.UNLIMITED:
+            limit = 'unlimited'
+        return limit
+
+COLUMNS['seed-ratio-limit'] = SeedRatioLimit
+
+class SeedRatioMode(ColumnBase):
+    header = {'left': 'Ratio limit mode'}
+    width = 5
+    min_width = 5
+    needed_keys = ('seed-ratio-mode',)
+
+    def get_value(self):
+        return self.data['seed-ratio-mode']
+
+COLUMNS['seed-ratio-mode'] = SeedRatioMode
 
 
 class RateUp(ColumnBase):

--- a/tests/tui_test/_handle_urwidpatches.py
+++ b/tests/tui_test/_handle_urwidpatches.py
@@ -1,22 +1,20 @@
-import importlib
 import sys
 
 
 def setUpModule():
     # Monkey-patch stuff in the urwid module in-place
-    if 'stig.tui.urwidpatches' not in sys.modules:
-        import stig.tui.urwidpatches
-    else:
-        import stig.tui.urwidpatches
-        importlib.reload(stig.tui.urwidpatches)
+    from stig.tui import urwidpatches
+    urwidpatches.apply_patches()
+
     import urwid
     assert hasattr(urwid.ListBox, 'get_scrollpos')
     assert ' ' not in urwid.command_map._command
 
 def tearDownModule(self):
     # Remove monkey patches
+    from stig.tui import urwidpatches
+    urwidpatches.revert_patches()
+
     import urwid
-    urwid.command_map.restore_defaults()
-    importlib.reload(urwid)
     assert not hasattr(urwid.ListBox, 'get_scrollpos')
     assert ' ' in urwid.command_map._command

--- a/tests/tui_test/keymap_test.py
+++ b/tests/tui_test/keymap_test.py
@@ -283,13 +283,12 @@ class TestKeyMap_with_single_keys(unittest.TestCase):
         self.km.bind(key='f', action='food', context='imhungry')
         self.km.unbind(key='f')
         self.assertIn(Key('f'), self.km.keys())
-        self.km.unbind(key='f', context='all')
+        self.km.unbind(key='f', context=self.km.ALL_CONTEXTS)
         self.assertNotIn(Key('f'), self.km.keys())
 
         with self.assertRaises(ValueError) as cm:
-            self.km.unbind(key='f', context='all')
-        self.assertIn("not mapped in any context", str(cm.exception))
-        self.assertIn(str(Key('f')), str(cm.exception))
+            self.km.unbind(key='f', context=self.km.ALL_CONTEXTS)
+        self.assertEqual(f"Key {str(Key('f'))} not mapped in any context.", str(cm.exception))
 
     def test_mkkey(self):
         self.assertEqual(self.km.mkkey(Key('x')), Key('x'))

--- a/tests/tui_test/keymap_test.py
+++ b/tests/tui_test/keymap_test.py
@@ -288,7 +288,7 @@ class TestKeyMap_with_single_keys(unittest.TestCase):
 
         with self.assertRaises(ValueError) as cm:
             self.km.unbind(key='f', context=self.km.ALL_CONTEXTS)
-        self.assertEqual(f"Key {str(Key('f'))} not mapped in any context.", str(cm.exception))
+        self.assertEqual('Key ' + str(Key('f')) + ' not mapped in any context.', str(cm.exception))
 
     def test_mkkey(self):
         self.assertEqual(self.km.mkkey(Key('x')), Key('x'))


### PR DESCRIPTION
A few TODOs:

1. Need a way to change the ratio limit mode between `GLOBAL`, `SINGLE`, and `UNLIMITED`. For ease of use the same command should be able to set the mode to both finite values and `UNLIMITED` (like how `-1` sometimes means unlimited or disabled).
2. Possibilities set
2. The output from `ls` should be formatted like it is in `details` view; e.g. if the mode is `GLOBAL` and `ratio-limit-enabled = false` it should display `disabled`. The logic is the same as in `details` view but importing `objects.remotecfg` causes a circular import. I'm not familiar enough with the code to resolve or work around this.
3. Annoyingly, the global properties do not follow the pattern of the other session properties (Sec 4.1 of the RPC spec), and they are `seedRatio*` in the RPC but `ratio-limit*` in the config file. Names in the code are possibly inconsistent and should be adjusted.