### PR TITLE
Add 'seeding' mode to torrent name view

### DIFF
--- a/stig/settings/default.theme
+++ b/stig/settings/default.theme
@@ -331,6 +331,11 @@ torrentlist.name.idle.progress2.focused            $name.idle_fg           on $t
 torrentlist.name.idle.complete.unfocused           $name.idle_fg           on $tlist_bg.uf
 torrentlist.name.idle.complete.focused             $name.idle_fg           on $tlist_bg.f
 
+$name.seeding_fg = $status.seeding_fg
+torrentlist.name.seeding.complete.unfocused           $name.seeding_fg           on $tlist_bg.uf
+torrentlist.name.seeding.complete.focused             $name.seeding_fg           on $tlist_bg.f
+
+
 $name.uploading_fg = $status.uploading_fg
 torrentlist.name.uploading.progress1.unfocused     $name.uploading_fg,underline on $tlist_bg.uf
 torrentlist.name.uploading.progress1.focused       $name.uploading_fg,underline on $tlist_bg.f

--- a/stig/tui/views/torrent.py
+++ b/stig/tui/views/torrent.py
@@ -48,7 +48,8 @@ class Name(_COLUMNS['name'], CellWidgetBase):
                          'downloading.progress1', 'downloading.progress2', 'downloading.complete',
                          'uploading.progress1', 'uploading.progress2', 'uploading.complete',
                          'queued.progress1', 'queued.progress2', 'queued.complete',
-                         'connected.progress1', 'connected.progress2', 'connected.complete'))
+                         'connected.progress1', 'connected.progress2', 'connected.complete',
+                         'seeding.complete'))
     header = urwid.AttrMap(ColumnHeaderWidget(**_COLUMNS['name'].header),
                            style.attrs('header'))
     needed_keys = ('name', 'status', '%downloaded', '%verified', '%metadata',
@@ -79,6 +80,8 @@ class Name(_COLUMNS['name'], CellWidgetBase):
             mode = 'queued'
         elif Status.CONNECTED in torrent['status']:
             mode = 'connected'
+        elif Status.SEED in torrent['status']:
+            mode = 'seeding'
         else:
             mode = 'idle'
         new_status = (torrent['name'], mode, progress)


### PR DESCRIPTION
It was not possible to theme the name column in torrentlists for the
seeding status. Trying to set 'torrentlist.name.seeding.complete'
analogously to other status-based themeing would raise a
ValidationError("Invalid attribute name").