### PR TITLE
Fix source comments typos and documentation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -183,7 +183,7 @@
 
   Other changes:
     * The 'set' command now shows a list of settings when called without
-      argments
+      arguments
     * The value of a setting can now come from shell command,
       e.g. `set connect.password:eval pass transmission`
     * Setting any list with a limited number of options to "*" sets it to all
@@ -406,7 +406,7 @@
       characters ('\t') as column delimiters in machine-readable output
 
   Other changes:
-    * New comand: 'peerlist'
+    * New command: 'peerlist'
     * New theme option 'bright_is_bold'
     * Paused torrents are blue instead of dark gray, which seems to have
       better contrast in most color schemes

--- a/stig/client/trequestpool.py
+++ b/stig/client/trequestpool.py
@@ -57,7 +57,7 @@ class TorrentRequestPool(RequestPoller):
         # # It's possible that a currently ongoing request doesn't collect the
         # # keys this new callback needs.  In that case, the request is finished
         # # AFTER we added the callback, and the callback would be called with
-        # # lacking keys, resuling in a KeyError.
+        # # lacking keys, resulting in a KeyError.
         # # Therefore we ask the poller to dump the result of a currently
         # # ongoing request to prevent this.
         # if self.running:

--- a/stig/commands/base/file.py
+++ b/stig/commands/base/file.py
@@ -142,7 +142,7 @@ class PriorityCmdbase(metaclass=CommandMeta):
             quiet = False
         else:
             # We're operating on focused or marked files and changes are
-            # indiciated by the updated file list, so no info messages
+            # indicated by the updated file list, so no info messages
             # necessary.
             quiet = True
 

--- a/stig/commands/cli/_table.py
+++ b/stig/commands/cli/_table.py
@@ -195,7 +195,7 @@ def _shrink_by_removing_columns(table):
             _set_colwidth(table, table.colorder.index(colname), new_width)
 
 def _fit_table_into_terminal(table):
-    # Expand all cells in each colum to the width of the widest cell
+    # Expand all cells in each column to the width of the widest cell
     # Keep track of each column width in table namespace
     for colindex,colname in enumerate(table.colorder):
         if _column_has_variable_width(table, colname):

--- a/stig/commands/utils.py
+++ b/stig/commands/utils.py
@@ -61,7 +61,7 @@ def log_msgs(process, response, quiet=False):
     instance) that take a single string and report it to the user.
 
     `response` must be an object with the attributes `msgs` and `errors` (i.e. a
-    Reponse instance).
+    Response instance).
 
     If `quiet` evaluates to True, only errors are reported.
     """

--- a/stig/helpmgr.py
+++ b/stig/helpmgr.py
@@ -352,7 +352,7 @@ class HelpManager():
 
                 if 'document_default' not in argspec or argspec['document_default']:
                     # Argument takes a value that may default to another value
-                    # if ommitted and we want to document that default value
+                    # if omitted and we want to document that default value
                     def stringify_default(default):
                         dflt = default() if callable(default) else default
 

--- a/stig/tui/group.py
+++ b/stig/tui/group.py
@@ -28,7 +28,7 @@ class _Fill(urwid.SolidFill):
 
 
 class Group(urwid.WidgetWrap):
-    """Wrapper aroung Pile or Columns widget
+    """Wrapper around Pile or Columns widget
 
     The purpose of this class it o make adding/removing, hiding/showing and
     accessing widgets simpler.
@@ -146,7 +146,7 @@ class Group(urwid.WidgetWrap):
             item = dict(name=name,            # Descriptive, unique handle
                         widget=widget,        # Bare widget
                         options=options,      # urwid options tuple, e.g. ('given',10) or ('weight',50)
-                        removable=removable)  # Wether this item can be deleted
+                        removable=removable)  # Whether this item can be deleted
 
             if position == 'start':
                 position = 0

--- a/stig/tui/scroll.py
+++ b/stig/tui/scroll.py
@@ -36,7 +36,7 @@ class Scrollable(urwid.WidgetDecoration):
 
         TODO: Focusable widgets are handled, including switching focus, but
         possibly not intuitively, depending on the arrangement of widgets.  When
-        switching focus to a widget that is ouside of the visible part of the
+        switching focus to a widget that is outside of the visible part of the
         original widget, the canvas scrolls up/down to the focused widget.  It
         would be better to scroll until the next focusable widget is in sight
         first.  But for that to work we must somehow obtain a list of focusable

--- a/stig/utils/cliparser.py
+++ b/stig/utils/cliparser.py
@@ -219,7 +219,7 @@ def _parse(string, delims=DEFAULT_DELIMS, escapes=DEFAULT_ESCAPES, quotes=DEFAUL
                 # Enable escaping state if this is the last character of the
                 # escape string (escape characters are not marked as escaped)
                 if i >= escape_index + len(escape) - 1:
-                    # Only mark escape characters that nned it
+                    # Only mark escape characters that need it
                     next_is_delim, _, _, _ = _on_any_substr(string, i + 1, delims)
                     if next_is_delim or next_is_quote or next_is_escape:
                         # log.debug('    Enabling escape state')
@@ -1111,7 +1111,7 @@ class Args(tuple):
             elif item.step is not None:
                 raise RuntimeError('Slicing with steps is not implemented yet')
             elif self.curarg_index is None or self.curarg_curpos is None:
-                # No cursor position specifed
+                # No cursor position specified
                 curarg_index = curarg_curpos = None
             else:
                 start = item.start if item.start is not None else 0

--- a/tests/client_test/poll_test.py
+++ b/tests/client_test/poll_test.py
@@ -123,7 +123,7 @@ class TestRequestPoller(asynctest.ClockedTestCase):
         self.assertEqual(status, 'None calls')
 
     async def test_request_raises_ClientError(self):
-        # Connection fails after a few successfull requests
+        # Connection fails after a few successful requests
         requests_before_failure = 3
         requests_before_different_failure = 6
         requests = 0


### PR DESCRIPTION
Found via `codespell -q3 -L fo,nam,trun,tthe`