### PR TITLE
Fix typos

### DIFF
--- a/stig/completion/__init__.py
+++ b/stig/completion/__init__.py
@@ -263,7 +263,7 @@ class Candidate(str):
 
 class SingleCandidate(Candidates):
     """
-    Dummy Candidates that contains only one replacable candidate
+    Dummy Candidates that contains only one replaceable candidate
 
     This is used to include current user input in its own category.
     """

--- a/tests/commands_test/tui_cmds_test.py
+++ b/tests/commands_test/tui_cmds_test.py
@@ -218,7 +218,7 @@ class TestUnbindCmd(CommandTestCase):
         cb.error.assert_not_called()
 
     @patch('stig.tui.tuiobjects.keymap', create=True, contexts=('foo', 'bar', 'baz'))
-    async def test_unbind_unbound_keys_in_specifc_context(self, mock_keymap):
+    async def test_unbind_unbound_keys_in_specific_context(self, mock_keymap):
         mock_keymap.unbind.side_effect = (None, ValueError('key not bound: b'), None)
         cb = Mock()
         process = UnbindCmd(['--context', 'foo', 'a', 'b', 'c'], info_handler=cb.info, error_handler=cb.error)

--- a/tests/tui_test/theme_test.py
+++ b/tests/tui_test/theme_test.py
@@ -51,10 +51,10 @@ class TestPalette(unittest.TestCase):
 
     def test_line_numbers_in_error_messages(self):
         with self.assertRaises(theme.ThemeError) as cm:
-            theme.Palette(('# coment',
-                           '# coment',
+            theme.Palette(('# comment',
+                           '# comment',
                            'statusbar white on black',
-                           '# coment',
+                           '# comment',
                            'loginform foo on black'))
         self.assertEqual(str(cm.exception), "Invalid color in line 5: 'foo'")
 


### PR DESCRIPTION
Found via `typos --format brief`