### PR TITLE
fix: catch the correct exception in _redraw_screen

### DIFF
--- a/stig/tui/main.py
+++ b/stig/tui/main.py
@@ -86,6 +86,6 @@ def _redraw_screen():
     try:
         from .tuiobjects import urwidloop
         urwidloop.draw_screen()
-    except AssertionError:
+    except (AssertionError, RuntimeError):
         # catches trying to redraw the screen before urwidloop has started
         pass


### PR DESCRIPTION
on startup `_redraw_screen` can be called before the urwid event loop has started, in which case `draw_screen` throws. (this is harmless.) before urwid commit `9e72578`, it would throw `AssertionError`; as of `9e72578` it throws `RuntimeError`. this fix ensures both are caught.