### PR TITLE
fix: catch malformed UTF-8 from server

### DIFF
--- a/stig/client/aiotransmission/rpc.py
+++ b/stig/client/aiotransmission/rpc.py
@@ -410,6 +410,8 @@ class TransmissionRPC():
                     answer = await response.json()
                 except json.JSONDecodeError as e:
                     raise RPCError('Server sent malformed JSON: %s: %s' % (e, await response.text()))
+                except UnicodeDecodeError as e:
+                    raise RPCError('Server sent malformed UTF-8: %s' % e)
                 else:
                     return answer
 


### PR DESCRIPTION
I've run into this a couple of times. I suspect it's an issue with transmission. E.g. transmission fails to sanitise file names that are not valid UTF-8 -- there's an [upstream crash report](https://github.com/transmission/transmission/issues/6349) related to that. In any case, malformed UTF-8 causes a crash because `response.json()` throws and `UnicodeDecodeError` is not caught. 