### PR TITLE
tui: improve performance for FileLists with many entries

### DIFF
--- a/stig/client/ttypes.py
+++ b/stig/client/ttypes.py
@@ -114,6 +114,8 @@ class TorrentFile(abc.Mapping):
         self._raw = {'tid': tid, 'id': id, 'name': name, 'path': path, 'location': location,
                      'is-wanted': is_wanted, 'priority': priority,
                      'size-total': size_total, 'size-downloaded': size_downloaded}
+        self._raw_keys = list(self._raw.keys())
+        self._raw_keys.sort()
         self._cache = {}
 
     def __getitem__(self, key):
@@ -144,6 +146,9 @@ class TorrentFile(abc.Mapping):
 
     def __repr__(self):
         return '<{} {!r}>'.format(type(self).__name__, self['name'])
+
+    def __hash__(self):
+        return hash(tuple([(self._raw[k]) for k in self._raw_keys]))
 
     def __iter__(self):
         return iter(self.TYPES)

--- a/stig/tui/views/file_list.py
+++ b/stig/tui/views/file_list.py
@@ -11,6 +11,7 @@
 
 import builtins
 from collections import abc
+from functools import lru_cache
 
 import urwid
 import urwidtrees
@@ -109,6 +110,7 @@ class FileTreeDecorator(ArrowTree):
         self.filecount = fcount
         return forest
 
+    @lru_cache(maxsize=1024)
     def decorate(self, pos, data, is_first=True):
         # We can use the tree position as table ID
         self._table.register(pos)
@@ -152,7 +154,6 @@ class FileTreeDecorator(ArrowTree):
     def widgets(self):
         """Yield all file and directory widgets in this tree"""
         yield from self._widgets.values()
-
 
 
 class FileItemWidget(ItemWidgetBase):

--- a/stig/views/file.py
+++ b/stig/views/file.py
@@ -156,7 +156,7 @@ class TorrentFileDirectory(dict):
             return str(name)
 
     def __hash__(self):
-        return hash(self['path'])
+        return hash(self.get('path', ''))
 
     def __repr__(self):
         return '<%s %s>' % (type(self).__name__, self['path-absolute'])


### PR DESCRIPTION
Torrent file lists with many (hundreds) of entries were extremely unresponsive. Profiling showed that this was due to `FileTreeDecorator.decorate()` calling `Table.register`, creating many new `Column` widgets with each frame update. By applying caching to `FileTreeDecorator.decorate()` we avoid this, and only create new widgets when data has changed. This requires making `TorrentFile` and `TorrentFileDirectory` hashable.