### PR TITLE
fix: remove superfluous `__ne__` methods

### DIFF
--- a/stig/utils/cliparser.py
+++ b/stig/utils/cliparser.py
@@ -105,9 +105,6 @@ class Char(str):
         else:
             return NotImplemented
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def __repr__(self):
         kwargs = {}
         if self._string: kwargs['string'] = self._string
@@ -930,9 +927,6 @@ class Arg(str):
         if not isinstance(other, type(self)):
             return NotImplemented
         return super().__eq__(other) and self.curpos == other.curpos
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
     def __hash__(self):
         return super().__hash__()


### PR DESCRIPTION
In Python 3.14 [`NotImplemented`](https://docs.python.org/3/library/constants.html#NotImplemented) can no longer be used in boolean contexts. That is, `not NotImplemented` will raise. The classes `utils.cliparser.Args, utils.cliparser.Char` had `__ne__` implemented as `not __eq__`, but could return `NotImplemented` from the latter, so they would raise in Python 3.14. The default implementation of `__ne__`  is sufficient:

> For [`__ne__()`](https://docs.python.org/3/reference/datamodel.html#object.__ne__), by default it delegates to [`__eq__()`](https://docs.python.org/3/reference/datamodel.html#object.__eq__) and inverts the result unless it is NotImplemented.

