### PR TITLE
labels: simplify completion for labels

### DIFF
--- a/stig/commands/base/torrent.py
+++ b/stig/commands/base/torrent.py
@@ -86,8 +86,7 @@ class AddTorrentsCmdbase(metaclass=CommandMeta):
                                       base=objects.cfg['srv.path.complete'],
                                       directories_only=True)
         if option == '--labels':
-            curlbl = args.curarg.split(',')[-1]
-            return candidates.labels(curlbl)
+            return candidates.labels()
 
 
 class TorrentDetailsCmdbase(mixin.get_single_torrent, metaclass=CommandMeta):
@@ -621,4 +620,4 @@ class LabelCmd(metaclass=CommandMeta):
     def completion_candidates_posargs(cls, args):
         """Complete positional arguments"""
         curlbl = args.curarg.split(',')[-1]
-        return candidates.labels(curlbl)
+        return candidates.labels()

--- a/stig/completion/candidates.py
+++ b/stig/completion/candidates.py
@@ -371,16 +371,14 @@ async def setting_filter(curarg, filter_names=True):
                          objects_getter=objects_getter,
                          items_getter=None,
                          filter_names=filter_names)
-async def labels(curarg):
+async def labels():
     """All labels"""
     labels = set()
-    if curarg != "":
-        response = await objects.srvapi.torrent.torrents(None, ('labels', ), from_cache=True)
-        [
-            [labels.add(l) for l in t["labels"] if l.startswith(curarg)]
-            for t in response.torrents
-        ]
-    return Candidates(list(labels), label=curarg, curarg_seps=',')
+    response = await objects.srvapi.torrent.torrents(None, ('labels', ), from_cache=True)
+    [
+        [labels.add(l) for l in t["labels"]] for t in response.torrents
+    ]
+    return Candidates(list(labels), label="Labels", curarg_seps=',')
 
 
 async def _filter(curarg, filter_cls_name, objects_getter, items_getter, filter_names):


### PR DESCRIPTION
The callers of `completion.candidates.labels()` were trying to do something that the completion engine already can handle (separate several values in one argument). In addition, the crash in #263 occurs on Python 3.14. `labels` now creates a `Candidates` object much like the `fs_path` and `sort_orders` candidate generators do.